### PR TITLE
🐞 fix(#151): 一部英文を大文字に変更

### DIFF
--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -59,7 +59,7 @@ fixed top-0 left-0 z-50
       </div>
 
       <p class="mt-14 font-serif-en md:text-xl">
-        Web design / Graphic design / Art direction
+        WEB DESIGN / GRAPHIC DESIGN / ART DIRECTION
       </p>
 
       <h1 class="flex items-end gap-4 md:gap-10 mt-3 md:mt-0">
@@ -81,7 +81,7 @@ fixed top-0 left-0 z-50
           <span
             class="font-serif-en text-sm md:text-lg leading-none whitespace-pre-line"
           >
-            <span>Portfolio</span>
+            <span>(PORTFOLIO)</span>
           </span>
           <span
             class="font-medium text-[2rem] md:text-5xl leading-none whitespace-pre-line"


### PR DESCRIPTION
This pull request includes changes to the `src/components/Hero/index.astro` file to update the text styling for better emphasis and clarity.

Text styling updates:

* Changed the case of the text from "Web design / Graphic design / Art direction" to "WEB DESIGN / GRAPHIC DESIGN / ART DIRECTION" for better emphasis.
* Added parentheses around the word "Portfolio" to "(PORTFOLIO)" for improved clarity.