### PR TITLE
🐞 fix(#152): sp時h1サイズ調整

### DIFF
--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -62,10 +62,10 @@ fixed top-0 left-0 z-50
         Web design / Graphic design / Art direction
       </p>
 
-      <h1 class="flex items-end gap-4 md:gap-10 mt-3 md:mt-0">
+      <h1 class="flex items-end justify-between md:justify-normal gap-4 md:gap-10 mt-3 md:mt-0">
         <picture
           id="hero-logo"
-          class="relative max-w-[20rem] md:max-w-[85rem] flex-1 is-loading [&.is-loading]:z-50"
+          class="relative max-w-[19.6rem] md:max-w-[85rem] flex-1 is-loading [&.is-loading]:z-50"
         >
           <source
             srcset={updatePath('/top/hero/fv-moving.png')}


### PR DESCRIPTION
This pull request includes a small change to the `src/components/Hero/index.astro` file. The change adjusts the layout and styling of the hero section to ensure better alignment and spacing.

* Modified the `h1` element to use `justify-between` for better alignment on smaller screens and `justify-normal` for medium screens.
* Adjusted the `max-w` property of the `picture` element to `19.6rem` for better visual consistency.