### PR TITLE
🐞 fix(#150): btnのdurationを0.6sに

### DIFF
--- a/src/components/Header/Menu.astro
+++ b/src/components/Header/Menu.astro
@@ -24,7 +24,7 @@ import updatePath from '@/libs/updatePath';
         class="ts-menu-close text-pampas font-serif-en border border-emperor
         rounded-[30px] py-[6px] px-4 flex gap-2 items-center
         absolute top-5 md:top-10 right-5 md:right-20
-        group transition-colors duration-700 hover:bg-pampas hover:text-mine-shaft"
+        group transition-colors duration-[0.6s] hover:bg-pampas hover:text-mine-shaft"
         data-stalker-color="bright"
       >
         <span class="inline-block">CLOSE</span>
@@ -61,7 +61,7 @@ import updatePath from '@/libs/updatePath';
                           transitionTimingFunction:
                             'cubic-bezier(0.16, 1, 0.3, 1)',
                         }}
-                        class="hidden md:block transition-all duration-700 absolute top-0 left-0 group-hover:opacity-0 group-hover:-translate-x-1/2"
+                        class="hidden md:block transition-all duration-[0.6s] absolute top-0 left-0 group-hover:opacity-0 group-hover:-translate-x-1/2"
                       >
                         <MenuLink menu={menu} />
                       </span>
@@ -72,7 +72,7 @@ import updatePath from '@/libs/updatePath';
                           transitionTimingFunction:
                             'cubic-bezier(0.16, 1, 0.3, 1)',
                         }}
-                        class="hidden md:block transition-all duration-700 absolute top-0 left-0 opacity-0 translate-x-1/2 group-hover:translate-x-0 group-hover:opacity-100"
+                        class="hidden md:block transition-all duration-[0.6s] absolute top-0 left-0 opacity-0 translate-x-1/2 group-hover:translate-x-0 group-hover:opacity-100"
                       >
                         <MenuLink menu={menu} />
                       </span>

--- a/src/components/More.astro
+++ b/src/components/More.astro
@@ -12,13 +12,13 @@ const { href, color } = Astro.props;
 <a
   href={updatePath(href)}
   class="ts-more group inline-block font-serif-en md:text-lg leading-none relative
-border rounded-[50%] py-5 md:py-6 px-10 md:px-12 transition-colors duration-1000 overflow-hidden
+border rounded-[50%] py-5 md:py-6 px-10 md:px-12 transition-colors duration-[0.6s] overflow-hidden
 data-[color='bright']:border-silver-chalice data-[color='bright']:text-pampas data-[color='bright']:hover:border-black data-[color='bright']:hover:text-black
 data-[color='dark']:border-gray data-[color='dark']:text-black data-[color='dark']:hover:border-pampas data-[color='dark']:hover:text-pampas"
   data-color={color}
 >
   <span
-    class="data-[color='bright']:bg-pampas data-[color='dark']:bg-black transition-all duration-1000 rounded-[50%]
+    class="data-[color='bright']:bg-pampas data-[color='dark']:bg-black transition-all duration-[0.6s] rounded-[50%]
   absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-0 h-0 z-0 group-hover:w-full group-hover:h-full"
     data-color={color}></span>
   <span class="relative z-0">MORE</span>


### PR DESCRIPTION
This pull request includes changes to the transition durations in the `Menu.astro` and `More.astro` components to ensure a consistent and smoother animation experience. The most important changes are as follows:

### Transition Duration Updates

* Updated the transition duration for the menu close button to `0.6s` in `src/components/Header/Menu.astro`.
* Changed the transition duration for the menu link hover effect to `0.6s` in `src/components/Header/Menu.astro`.
* Modified the transition duration for the menu link appearance to `0.6s` in `src/components/Header/Menu.astro`.
* Adjusted the transition duration for the "More" button hover effect to `0.6s` in `src/components/More.astro`.