### PR TITLE
🐞 fix(#141): transition 無効な指定を修正

### DIFF
--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -22,7 +22,7 @@ const path = Astro.url.pathname;
   <div class="container flex items-start py-5 md:py-10 px-5 md:px-20">
     <a
       href={updatePath('/')}
-      class="ts-logo transision-colors [&_svg]:fill-silver-chalice hover:opacity-30 transition-opacity"
+      class="ts-logo transition-all [&_svg]:fill-silver-chalice hover:opacity-30"
       aria-label="TAIKI SATO"
     >
       <Logo />
@@ -30,7 +30,7 @@ const path = Astro.url.pathname;
     <ul
       class="ts-header-list ml-auto gap-8 hidden md:flex
       ease-in-out max-h-[var(--header-list-height)]
-      transision-colors group-[header]:data-[color=dark]:text-pampas"
+      transition-colors group-[header]:data-[color=dark]:text-pampas"
     >
       {
         headerLinks.map(link => (

--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -6,7 +6,7 @@ import updatePath from '@/libs/updatePath';
 <PageLoader isOpening={true} />
 <div
   id="opening-bg"
-  class="bg-mine-shaft-texture w-screen h-lvh transision-all duration-700
+  class="bg-mine-shaft-texture w-screen h-lvh transition-all duration-700
 fixed top-0 left-0 z-50
 [&.is-hidden]:opacity-0 [&.is-hidden]:invisible"
 >
@@ -38,7 +38,7 @@ fixed top-0 left-0 z-50
         id="hero-video"
         class="absolute z-0 top-0 left-1/2 -translate-x-1/2
         w-screen h-full overflow-hidden opacity-50
-        mix-blend-multiply transision-all duration-700
+        mix-blend-multiply transition-all duration-700
         is-loading [&.is-loading]:z-50"
       >
         <video

--- a/src/components/PageLoader/index.astro
+++ b/src/components/PageLoader/index.astro
@@ -8,7 +8,7 @@ const { isOpening = false } = Astro.props;
 <div
   class="ts-page-loader w-screen h-dvh
 bg-transparent backdrop-blur fixed
-top-0 left-0 z-50 transision-all duration-700
+top-0 left-0 z-50 transition-all duration-700
 [&.is-hidden]:opacity-0 [&.is-hidden]:invisible"
   data-opening={isOpening ? 'true' : 'false'}
 >


### PR DESCRIPTION
This pull request focuses on fixing a recurring typo in class names across multiple files. The typo "transision" has been corrected to "transition".

Typo corrections:

* [`src/components/Header/index.astro`](diffhunk://#diff-f0ebddc6b4736d396c8f03e9b66a8209577db29edbc315e379e8906d89e0f863L25-R33): Corrected "transision-colors" to "transition-colors" and "transision-all" to "transition-all".
* [`src/components/Hero/index.astro`](diffhunk://#diff-f486c0c56c5cc37d1417cd1a77815410a30fb548cfc4f5e5616ba26427641b07L9-R9): Corrected "transision-all" to "transition-all" in two instances. [[1]](diffhunk://#diff-f486c0c56c5cc37d1417cd1a77815410a30fb548cfc4f5e5616ba26427641b07L9-R9) [[2]](diffhunk://#diff-f486c0c56c5cc37d1417cd1a77815410a30fb548cfc4f5e5616ba26427641b07L41-R41)
* [`src/components/PageLoader/index.astro`](diffhunk://#diff-101fe0ab3ab0b92f70c91cf529abbe501721cf96ab34d2934c853910d5be1ed9L11-R11): Corrected "transision-all" to "transition-all".

#141 