### PR TITLE
🐞 fix(#143): about sp画像サイズ調整

### DIFF
--- a/src/data/parallaxGalleryItems.ts
+++ b/src/data/parallaxGalleryItems.ts
@@ -10,44 +10,44 @@ const parallaxGalleryItems: ParallaxGalleryItems = {
     {
       src: '/top/about/left-01.jpg',
       alt: 'left-01',
-      class: 'w-40 md:w-[27rem] md:ml-[10rem]',
+      class: 'w-46 md:w-[27rem] md:ml-[10rem]',
     },
     {
       src: '/top/about/left-02.jpg',
       alt: 'left-02',
-      class: 'w-24 md:w-[14rem] mt-28 md:mt-[15rem] -ml-12 md:ml-0',
+      class: 'w-28 md:w-[14rem] mt-28 md:mt-[15rem] -ml-12 md:ml-0',
     },
     {
       src: '/top/about/left-03.jpg',
       alt: 'left-03',
-      class: 'w-40 md:w-[21rem] mt-40 md:mt-[3.75rem] ml-14 md:ml-[34rem]',
+      class: 'w-46 md:w-[21rem] mt-40 md:mt-[3.75rem] ml-14 md:ml-[34rem]',
     },
     {
       src: '/top/about/left-04.jpg',
       alt: 'left-04',
-      class: 'w-28 md:w-[21rem] mt-7 md:mt-[7rem] -ml-3 md:ml-[2.8rem]',
+      class: 'w-32 md:w-[21rem] mt-7 md:mt-[7rem] -ml-3 md:ml-[2.8rem]',
     },
   ],
   right: [
     {
       src: '/top/about/right-01.jpg',
       alt: 'right-01',
-      class: 'w-32 md:w-[26rem] mt-20 md:mt-[13rem] -mr-10 md:mr-[6rem]',
+      class: 'w-37 md:w-[26rem] mt-20 md:mt-[13rem] -mr-10 md:mr-[6rem]',
     },
     {
       src: '/top/about/right-02.jpg',
       alt: 'right-02',
-      class: 'w-24 md:w-[12.5rem] mt-20 md:mt-[6rem]',
+      class: 'w-28 md:w-[12.5rem] mt-20 md:mt-[6rem]',
     },
     {
       src: '/top/about/right-03.jpg',
       alt: 'right-03',
-      class: 'w-28 md:w-[22rem] mt-6 md:mt-[7.3rem] mr-3 md:mr-[24rem]',
+      class: 'w-32 md:w-[22rem] mt-6 md:mt-[7.3rem] mr-3 md:mr-[24rem]',
     },
     {
       src: '/top/about/right-04.jpg',
       alt: 'right-04',
-      class: 'w-36 md:w-[30rem] mt-20 md:mt-[7rem] -mr-8 md:-mr-[3rem]',
+      class: 'w-41 md:w-[30rem] mt-20 md:mt-[7rem] -mr-8 md:-mr-[3rem]',
     },
   ],
 };


### PR DESCRIPTION
This pull request includes changes to the `src/data/parallaxGalleryItems.ts` file to update the `class` values for various gallery items. These updates adjust the width of the images in the parallax gallery.

Changes to image widths:

* Updated the `class` value for the left-side images to increase their widths. (`[src/data/parallaxGalleryItems.tsL13-R50](diffhunk://#diff-0e6a044fb1b24b6be11fe30fa412ff30e3a9624ce154246d215cbdbfee2ab212L13-R50)`)
* Updated the `class` value for the right-side images to increase their widths. (`[src/data/parallaxGalleryItems.tsL13-R50](diffhunk://#diff-0e6a044fb1b24b6be11fe30fa412ff30e3a9624ce154246d215cbdbfee2ab212L13-R50)`)