### PR TITLE
🐞 fix(#145): ロゴと作品集間のスペースを修正

### DIFF
--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -67,7 +67,7 @@ fixed top-0 left-0 z-50
       >
         <picture
           id="hero-logo"
-          class="relative max-w-[19.6rem] md:max-w-[85rem] flex-1 is-loading [&.is-loading]:z-50"
+          class="relative max-w-[19.6rem] md:max-w-[85rem] is-loading [&.is-loading]:z-50"
         >
           <source
             srcset={updatePath('/top/hero/fv-moving.png')}


### PR DESCRIPTION
This pull request includes a small change to the `src/components/Hero/index.astro` file. The change removes the `flex-1` class from the `picture` element with the ID `hero-logo` to adjust its styling.

#145 