### PR TITLE
🐞 fix: 背景 z-index修正

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,7 +59,7 @@ const bodyClass = cn({
   <body class={bodyClass} data-bg-color={theme}>
     {
       theme === 'bright' && (
-        <div class="bg-gray-texture w-screen h-screen fixed top-0 left-0" />
+        <div class="bg-gray-texture w-screen h-screen fixed top-0 left-0 -z-10" />
       )
     }
     <PageLoader color={theme} />


### PR DESCRIPTION
This pull request includes a minor change to the `src/layouts/Layout.astro` file. The change adjusts the z-index of a background texture div to ensure it is placed behind other content.

* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L62-R62): Added `-z-10` class to the `div` element with class `bg-gray-texture` to set its z-index to -10.