### PR TITLE
🐞 fix(#207): Stalker 挿入位置修正

### DIFF
--- a/src/pages/works/textile-manufacturer.astro
+++ b/src/pages/works/textile-manufacturer.astro
@@ -178,10 +178,10 @@ const { work, nextWork } = getWork(pathname);
 
       <BackToList />
       <NextWork work={nextWork} />
-
-      <Stalker client:only="react" />
     </div>
   </section>
+
+  <Stalker client:only="react" />
 </Layout>
 
 <script>


### PR DESCRIPTION
This pull request includes a change to the `src/pages/works/textile-manufacturer.astro` file to adjust the placement of the `Stalker` component. The `Stalker` component was moved outside of the `<section>` element and placed directly under the `<Layout>` component.

* [`src/pages/works/textile-manufacturer.astro`](diffhunk://#diff-807d787f84f4bf02e0a207a4358e2c4576f7e0030ead5f01c8253ee266acb802L181-R184): Moved the `Stalker` component outside of the `<section>` element and placed it directly under the `<Layout>` component.

#207 