### PR TITLE
✨ feat(#179): 一覧へ戻る hoverエフェクト追加

### DIFF
--- a/src/components/BackToList.astro
+++ b/src/components/BackToList.astro
@@ -5,10 +5,14 @@ import updatePath from '@/libs/updatePath';
 <div class="flex items-center justify-center md:ml-[7.5rem]">
   <a
     href={updatePath('/works/')}
-    class="inline-flex items-center hover:opacity-80 transition-opacity mt-12 md:mt-0"
+    class="group inline-flex items-center mt-12 md:mt-0"
   >
     <span
-      class="border border-black rounded-full flex justify-center items-center w-[1.7rem] md:w-[2rem] h-[1.7rem] md:h-[2rem]"
+      class="border border-black text-black
+        group-hover:bg-black group-hover:text-white
+        transition-colors duration-700
+        rounded-full flex justify-center items-center
+        w-[1.7rem] md:w-[2rem] h-[1.7rem] md:h-[2rem]"
       aria-hidden="true"
     >
       <svg
@@ -20,7 +24,7 @@ import updatePath from '@/libs/updatePath';
       >
         <path
           d="M6.07157 7.703C6.07157 7.703 5.14179 6.02754 4.92111 4.53711L11.3711 4.19307L11.3711 3.70154L4.92735 3.35749C5.17107 1.88795 6.18137 0.296124 6.18137 0.296124C6.18137 0.296124 3.11268 3.53318 0.303436 3.9515C3.1044 4.37403 6.07157 7.70312 6.07157 7.70312L6.07157 7.703Z"
-          fill="#3D3D3D"></path>
+          class="fill-current"></path>
       </svg>
     </span>
     <span class="md:text-lg ml-4">一覧へ戻る</span>


### PR DESCRIPTION
This pull request includes updates to the `BackToList` component to improve its styling and behavior. The most important changes include modifying the link's hover effect and updating the SVG path's fill color.

Styling improvements:

* [`src/components/BackToList.astro`](diffhunk://#diff-3547c43b1e75492fd1c8d70f27a62df1dde24b59605ea850635804006a8d3861L8-R15): Changed the link's class to include a hover effect that transitions the background and text color over 700ms.
* [`src/components/BackToList.astro`](diffhunk://#diff-3547c43b1e75492fd1c8d70f27a62df1dde24b59605ea850635804006a8d3861L23-R27): Updated the SVG path to use `fill-current` class for dynamic color changes based on the current text color.

#179 