### PR TITLE
🐞 fix(#226): SP私についてリンク アイコンずれを修正

### DIFF
--- a/src/components/WorksSlide/index.tsx
+++ b/src/components/WorksSlide/index.tsx
@@ -110,17 +110,18 @@ const WorksSlide = ({ title, titleEn, items, path }: Props) => {
             <li className="pr-10 flex items-center">
               <a
                 href="/about"
-                className="group text-2xl md:text-[2rem] font-medium ml-24 md:ml-72"
+                className="group text-2xl md:text-[2rem] font-medium ml-24 md:ml-72
+                  inline-flex flex-col items-center"
               >
                 <span className="vertical-rl">
                   <span>私について</span>
                 </span>
                 <span
                   className="border border-black text-black
-                group-hover:bg-black group-hover:text-white
-                  mt-6 md:mt-9 mx-auto transition-colors duration-700
-                  rounded-full flex justify-center items-center
-                  w-[1.5rem] md:w-[2rem] h-[1.5rem] md:h-[2rem]"
+                  group-hover:bg-black group-hover:text-white
+                    mt-6 md:mt-9 mx-auto transition-colors duration-700
+                    rounded-full flex justify-center items-center
+                    w-[1.5rem] md:w-[2rem] h-[1.5rem] md:h-[2rem]"
                   aria-hidden="true"
                 >
                   <svg


### PR DESCRIPTION
This pull request includes a small change to the `src/components/WorksSlide/index.tsx` file to improve the layout of a link element. The change modifies the class list of the `<a>` tag to include `inline-flex` and `flex-col` for better alignment.

* [`src/components/WorksSlide/index.tsx`](diffhunk://#diff-375ad2047eb289b720843505490410ee6300967f062d0f4916964b28a63fe759L113-R114): Added `inline-flex` and `flex-col` classes to the `<a>` tag inside the `WorksSlide` component to enhance the layout and alignment.

fix #226 