### PR TITLE
🐞 fix(#230): add lang="scss"

### DIFF
--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -71,7 +71,7 @@ const path = Astro.url.pathname;
   menuToggle();
 </script>
 
-<style>
+<style lang="scss">
   .ts-header-list {
     transition: all 0.5s ease-in-out;
   }

--- a/src/components/Scroll.astro
+++ b/src/components/Scroll.astro
@@ -16,7 +16,7 @@ transition-all duration-700 [&.is-invisible]:invisible
   </div>
 </div>
 
-<style>
+<style lang="scss">
   .scroll__inside {
     animation: scrollNav 3s infinite;
   }

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -18,7 +18,7 @@ const titleEn = 'WORKS';
   />
 </Layout>
 
-<style>
+<style lang="scss">
   .ts-text-link {
     span {
       justify-content: center;


### PR DESCRIPTION
This pull request includes changes to the styling language used in several Astro component files. The changes involve switching from plain CSS to SCSS for better styling capabilities.

Styling language changes:

* [`src/components/Header/index.astro`](diffhunk://#diff-f0ebddc6b4736d396c8f03e9b66a8209577db29edbc315e379e8906d89e0f863L74-R74): Changed the `<style>` tag to use `lang="scss"` for the header component.
* [`src/components/Scroll.astro`](diffhunk://#diff-96379ba6842fd19b3ac159fb6bd59f56d0e7862e91432448391ee2b0951e0714L19-R19): Changed the `<style>` tag to use `lang="scss"` for the scroll component.
* [`src/pages/works.astro`](diffhunk://#diff-74e1ee559e45fb8c1df3ddff86c00a7a1b2b46d427f723a32432815c0e47679eL21-R21): Changed the `<style>` tag to use `lang="scss"` for the works page.

fix #230 