### PR TITLE
🐞 fix(#237): リダイレクトを削除し、配置パスを明示

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,9 +23,6 @@ export default defineConfig({
   prefetch: {
     prefetchAll: true,
   },
-  redirects: {
-    '/~partytown': '/partytown',
-  },
   integrations: [
     tailwind(),
     sitemap(),
@@ -33,6 +30,7 @@ export default defineConfig({
     partytown({
       config: {
         forward: ['dataLayer.push'],
+        lib: '/partytown/',
       },
     }),
   ],


### PR DESCRIPTION
This pull request includes a modification to the `astro.config.mjs` file to remove unnecessary redirects and update the configuration for the `partytown` integration.

Configuration changes:

* Removed the `redirects` configuration that redirected `/~partytown` to `/partytown`.
* Updated the `partytown` integration configuration to include the `lib` property with the value `'/partytown/'`.

#237 