### PR TITLE
🐞 fix(#237): gh-pagesでも動くように

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
     partytown({
       config: {
         forward: ['dataLayer.push'],
-        lib: '/partytown/',
+        lib: `${base}/partytown/`,
       },
     }),
   ],


### PR DESCRIPTION
This pull request includes a small but important change to the `astro.config.mjs` file. The change updates the `lib` path configuration for the Partytown integration to use a dynamic base URL.

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL33-R33): Updated the `lib` path in the Partytown configuration to use a dynamic base URL (`${base}/partytown/`).